### PR TITLE
Fix compatibility with version 9.0.0 of more-itertools

### DIFF
--- a/plover_stenograph_wifi.py
+++ b/plover_stenograph_wifi.py
@@ -208,7 +208,7 @@ class StenoPacket(object):
         assert self.packet_id == self.ID_READ
 
         strokes = []
-        for stroke_data in grouper(8, self.data, 0):
+        for stroke_data in grouper(self.data, 8, fillvalue=0):
             stroke = []
             # Get 4 bytes of steno, ignore timestamp.
             for steno_byte, key_chart_row in zip(stroke_data, STENO_KEY_CHART):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ tests_require =
 	mock
 install_requires =
 	plover>=4.0.0.dev5
-	more_itertools
+	more_itertools>=6.0.0
 py_modules =
 	plover_stenograph_wifi
 


### PR DESCRIPTION
The argument order here was switched in version 6.0.0 of more-itertools, but the old order still worked until version 9.0.0.

The current signature is:
    grouper(iterable, n, incomplete='fill', fillvalue=None)

This commit updates the code to match the new signature, and bumps the minimum version of more-itertools to 6.0.0.

Unfortunately I can't test this change since I don't have a Wi-Fi enabled Stenograph machine, but I've tested a similar change to plover-stenograph and plover_stenograph_usb.